### PR TITLE
Java 17 and update

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>slingr-services-builder</artifactId>
+    <groupId>io.github.slingr-stack</groupId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml/pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>proxy</artifactId>
+  <name>SLINGR - Dev Services Proxy</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>Default component to manage a connection from your local to a Slingr service of the Slingr platform</description>
+  <repositories>
+    <repository>
+      <id>clojars</id>
+      <name>Clojars repository</name>
+      <url>https://clojars.org/repo</url>
+    </repository>
+  </repositories>
+  <properties>
+    <build.main-class>io.slingr.services.proxy.Runner</build.main-class>
+    <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+  </properties>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>io.slingr.services</groupId>
+    <parent>
+        <groupId>io.github.slingr-stack</groupId>
+        <artifactId>slingr-services-builder</artifactId>
+        <version>1.0.0</version>
+    </parent>
     <artifactId>proxy</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <name>SLINGR - Dev Services Proxy</name>
+    <description>Default component to manage a connection from your local to a Slingr service of the Slingr platform</description>
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.0-SNAPSHOT</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <!-- Dependency versions -->
         <!-- Build properties -->
-        <jdk.version>11</jdk.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.compiler.version>2.5.1</project.build.compiler.version>
-        <project.build.source.version>3.0.1</project.build.source.version>
-        <project.build.shade.version>2.4.1</project.build.shade.version>
-        <!-- Other properties -->
         <build.main-class>io.slingr.services.proxy.Runner</build.main-class>
     </properties>
     <dependencies>
@@ -31,107 +29,9 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>Central</id>
-            <name>Central</name>
-            <url>http://repo1.maven.org/maven2/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>slingrRepo.release</id>
-            <url>http://repo.slingrs.io/release</url>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>fail</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>slingrRepo.snapshot</id>
-            <url>http://repo.slingrs.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-        </repository>
-        <repository>
             <id>clojars</id>
             <name>Clojars repository</name>
             <url>https://clojars.org/repo</url>
         </repository>
     </repositories>
-    <distributionManagement>
-        <repository>
-            <id>slingrRepo.write.release</id>
-            <url>gs://repo.slingrs.io/release</url>
-        </repository>
-        <snapshotRepository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
-        </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${project.build.compiler.version}</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <!-- This plugin is used to generate the JAR with all the dependencies, which is needed
-            when deploying the service in the platform (not development mode). -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${project.build.shade.version}</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <manifestEntries>
-                                <Main-Class>${build.main-class}</Main-Class>
-                                <X-Compile-Source-JDK>${jdk.version}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${jdk.version}</X-Compile-Target-JDK>
-                            </manifestEntries>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                            <addHeader>false</addHeader>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/services/org/apache/camel/component.properties</exclude>
-                                <exclude>META-INF/services/org/apache/camel/dataformat.properties</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/public_pom.xml
+++ b/public_pom.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>io.slingr.services</groupId>
+    <parent>
+        <groupId>io.github.slingr-stack</groupId>
+        <artifactId>slingr-services-builder</artifactId>
+        <version>1.0.0</version>
+    </parent>
     <artifactId>proxy</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <name>SLINGR - Dev Services Proxy</name>
+    <description>Default component to manage a connection from your locañ to a Slingr service of the Slingr platform</description>
     <packaging>jar</packaging>
     <properties>
         <!-- Slingr versions -->
-        <slingr.slingr-service.version>1.0-SNAPSHOT</slingr.slingr-service.version>
+        <slingr.slingr-service.version>1.4.0</slingr.slingr-service.version>
+        <!-- Dependency versions -->
         <!-- Build properties -->
-        <jdk.version>11</jdk.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.compiler.version>2.5.1</project.build.compiler.version>
-        <project.build.source.version>3.0.1</project.build.source.version>
-        <project.build.shade.version>2.4.1</project.build.shade.version>
-        <!-- Other properties -->
         <build.main-class>io.slingr.services.proxy.Runner</build.main-class>
     </properties>
     <dependencies>
@@ -31,107 +29,9 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>Central</id>
-            <name>Central</name>
-            <url>http://repo1.maven.org/maven2/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>slingrRepo.release</id>
-            <url>http://repo.slingrs.io/release</url>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>fail</checksumPolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>slingrRepo.snapshot</id>
-            <url>http://repo.slingrs.io/snapshot</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-        </repository>
-        <repository>
             <id>clojars</id>
             <name>Clojars repository</name>
             <url>https://clojars.org/repo</url>
         </repository>
     </repositories>
-    <distributionManagement>
-        <repository>
-            <id>slingrRepo.write.release</id>
-            <url>gs://repo.slingrs.io/release</url>
-        </repository>
-        <snapshotRepository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
-        </snapshotRepository>
-    </distributionManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${project.build.compiler.version}</version>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <!-- This plugin is used to generate the JAR with all the dependencies, which is needed
-            when deploying the service in the platform (not development mode). -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${project.build.shade.version}</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <manifestEntries>
-                                <Main-Class>${build.main-class}</Main-Class>
-                                <X-Compile-Source-JDK>${jdk.version}</X-Compile-Source-JDK>
-                                <X-Compile-Target-JDK>${jdk.version}</X-Compile-Target-JDK>
-                            </manifestEntries>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                            <addHeader>false</addHeader>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/services/org/apache/camel/component.properties</exclude>
-                                <exclude>META-INF/services/org/apache/camel/dataformat.properties</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/java/io/slingr/services/proxy/Proxy.java
+++ b/src/main/java/io/slingr/services/proxy/Proxy.java
@@ -44,8 +44,8 @@ import java.util.Map;
  */
 @SuppressWarnings("unchecked")
 @SlingrService(name = "proxy")
-public class ProxyService extends Service {
-    private static final Logger logger = LoggerFactory.getLogger(ProxyService.class);
+public class Proxy extends Service {
+    private static final Logger logger = LoggerFactory.getLogger(Proxy.class);
 
     private static final String DATA_STORE_NAME = "__ds_name__";
     private static final String DATA_STORE_NEW_ID = "__ds_id__";

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,5 @@
-log4j.rootLogger=info, ${ROOT_LOGGER}
+# Root logger option
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.logentries=com.logentries.log4j.LogentriesAppender
 log4j.appender.logentries.layout=io.slingr.services.services.logs.ServiceLayout

--- a/src/main/resources/service.properties
+++ b/src/main/resources/service.properties
@@ -7,7 +7,7 @@ _profile=default
 _custom_domain=
 
 _debug=true
-_local_deployment=false
+_local_deployment=true
 
 _webservices_port=10000
 _base_domain=localhost:8000


### PR DESCRIPTION
Pull-request for issue https://github.com/slingr-stack/platform/issues/15600 created by @pasaperez-slingr 

## What it does?

Migrate the proxy-service to use java 17. 
Now the pom.xml is less dependent on the build options. It only takes care of the service specific code.

## How to test it?

You can test this service running the http-service and this service in parallel and try execute a webhook, this should arrive to http-service.

Test with any service in develop branch.

Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.

## Technical notes

There aren't technical notes

## Deployment notes

Create a new tag and build in each version.